### PR TITLE
Fix wrongly-typed strings

### DIFF
--- a/catchcopy-windows-explorer-plugin/CatchCopy.pro
+++ b/catchcopy-windows-explorer-plugin/CatchCopy.pro
@@ -1,5 +1,7 @@
 QT       -= core gui
 
+DEFINES += UNICODE _UNICODE
+
 CONFIG += 32bit
 
 CONFIG(32bit) {

--- a/catchcopy-windows-explorer-plugin/DDShellExt.cpp
+++ b/catchcopy-windows-explorer-plugin/DDShellExt.cpp
@@ -150,8 +150,8 @@ STDMETHODIMP CDDShellExt::QueryContextMenu(HMENU hmenu,UINT uMenuIndex,UINT uidF
 
 	int x=uidFirstCmd;
 
-    InsertMenu(hmenu,uMenuIndex++,MF_STRING|MF_BYPOSITION,x++,(const wchar_t*)_T("Copy-"));
-    InsertMenu(hmenu,uMenuIndex++,MF_STRING|MF_BYPOSITION,x++,(const wchar_t*)_T("Move-"));
+    InsertMenu(hmenu,uMenuIndex++,MF_STRING|MF_BYPOSITION,x++,_T("Copy-"));
+    InsertMenu(hmenu,uMenuIndex++,MF_STRING|MF_BYPOSITION,x++,_T("Move-"));
 
 	int defItem=GetMenuDefaultItem(hmenu,false,0);
 	if (defItem==1) // 1: Copy


### PR DESCRIPTION
Fix the weird Chinese chars:

python -c 'print "Copy".decode("utf-16").encode("utf-8")'
